### PR TITLE
Automatically update the wiki pages with generated docs from GDevelop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - '83:45:4c:d2:b2:ed:27:bd:84:a3:eb:0c:00:91:f8:60'
+            - '62:5b:c2:0d:b2:94:8d:ef:4c:2f:35:a2:55:e7:42:2b'
 
       # Install dependencies
       - run:
@@ -19,8 +20,8 @@ jobs:
           command: sudo apt update -y
 
       - run:
-          name: Install Doxygen
-          command: sudo apt install -y doxygen
+          name: Install Doxygen and rsync
+          command: sudo apt install -y doxygen rsync
 
       # Generate the docs
       - run:
@@ -48,6 +49,18 @@ jobs:
       - run:
           name: Deploy docs to gh-pages branch
           command: cd GDevelop && gh-pages --dist docs --repo 'https://github.com/4ian/GDevelop-documentation.git' --message "Update documentation [ci skip]"
+
+      - run:
+          name: Deploy docs to the wiki
+          command: |
+            mkdir -p ~/.ssh
+            echo '# home238011373.1and1-data.host:22 SSH-2.0-OpenSSH_7.9p1 Debian-10+deb10u1~ui10+2' >> ~/.ssh/known_hosts
+            echo 'home238011373.1and1-data.host ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/tKA7T9UUfVZ4gSGezw3t98UQcWwtHqPildhNL7F4SKhhXJorT01hwqsTVPXz9Emr1IzS9iOvvynqh7N3xSs01qoucho8WeantCVI5H7Vwt00qS8z8BRiYk1WpyzJfUCNUUHSJhF5SJd03uWrP19AhGsqqj7/24IzGhqxN/FqHgHdBRkQB//XlHhw5e03DPkr5jQRlHjSb9lkWily0/meBTkd7lFRC2n0sT/KE4XbjpvQlc2IUIIeWHJfcsJgpaGcDFboN9oV//voE4A0pdAFwE4OByVDZa/ifgXRlT0k5vVS+EaxTtH8idiu6ZV/P7dLMDo7b76KTSxlSixn7hPh' >> ~/.ssh/known_hosts
+            echo '# home238011373.1and1-data.host:22 SSH-2.0-OpenSSH_7.9p1 Debian-10+deb10u1~ui10+2' >> ~/.ssh/known_hosts
+            echo 'home238011373.1and1-data.host ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFjDE2sDVlaHhXudMMsLEuJvY+nBuTbwLGpQkLaJ5oxIR9vXinw/2dSzqnDAlrmJ1ZgWKQnvPh7Mz770Hp/sobU=' >> ~/.ssh/known_hosts
+            echo '# home238011373.1and1-data.host:22 SSH-2.0-OpenSSH_7.9p1 Debian-10+deb10u1~ui10+2' >> ~/.ssh/known_hosts
+            echo 'home238011373.1and1-data.host ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINbBMvvDjN4IP04VAZlDH42A+HL25ifeIK9CorAvaMA/' >> ~/.ssh/known_hosts
+            rsync -r GDevelop/docs-wiki/ $WIKI_USERNAME@$WIKI_HOSTNAME:~/gdevelop-wiki/dokuwiki/data/pages/gdevelop5
 
 workflows:
   version: 2


### PR DESCRIPTION
This automatically update the wiki with the community based extensions and the documentation generated from all the "official" GDevelop extensions. This will be run every day as already done for the automated documentation of the codebase.